### PR TITLE
06_ownership - initial implementation

### DIFF
--- a/06_ownership/src/lib.rs
+++ b/06_ownership/src/lib.rs
@@ -34,16 +34,16 @@ impl Ticket {
         }
     }
 
-    pub fn title(self) -> String {
-        self.title
+    pub fn title(&self) -> &String {
+        &self.title
     }
 
-    pub fn description(self) -> String {
-        self.description
+    pub fn description(&self) -> &String {
+        &self.description
     }
 
-    pub fn status(self) -> String {
-        self.status
+    pub fn status(&self) -> &String {
+        &self.status
     }
 }
 


### PR DESCRIPTION
Changed the existing implementation of Ticket's accessor methods to take a reference to 'self' as an argument, rather than taking ownership of it.