### PR TITLE
10_references_in_memory - initial commit

### DIFF
--- a/10_references_in_memory/src/lib.rs
+++ b/10_references_in_memory/src/lib.rs
@@ -4,8 +4,6 @@ pub struct Ticket {
     status: String,
 }
 
-// TODO: based on what you learned in this section, replace `todo!()` with
-//  the correct **stack size** for the respective type.
 #[cfg(test)]
 mod tests {
     use super::Ticket;
@@ -13,16 +11,16 @@ mod tests {
 
     #[test]
     fn u16_ref_size() {
-        assert_eq!(size_of::<&u16>(), todo!());
+        assert_eq!(size_of::<&u16>(), size_of::<usize>());
     }
 
     #[test]
     fn u64_mut_ref_size() {
-        assert_eq!(size_of::<&mut u64>(), todo!());
+        assert_eq!(size_of::<&mut u64>(), size_of::<usize>());
     }
 
     #[test]
     fn ticket_ref_size() {
-        assert_eq!(size_of::<&Ticket>(), todo!());
+        assert_eq!(size_of::<&Ticket>(), size_of::<usize>());
     }
 }


### PR DESCRIPTION
Replaced todo!() with the correct stack size for the respective type in 10_references_in_memory/src/lib.rs .