### PR TITLE
Const values in tests

### DIFF
--- a/10_references_in_memory/src/lib.rs
+++ b/10_references_in_memory/src/lib.rs
@@ -9,18 +9,20 @@ mod tests {
     use super::Ticket;
     use std::mem::size_of;
 
+    const USIZE_64BIT_IN_BYTES: usize = 8;
+
     #[test]
     fn u16_ref_size() {
-        assert_eq!(size_of::<&u16>(), size_of::<usize>());
+        assert_eq!(size_of::<&u16>(), USIZE_64BIT_IN_BYTES);
     }
 
     #[test]
     fn u64_mut_ref_size() {
-        assert_eq!(size_of::<&mut u64>(), size_of::<usize>());
+        assert_eq!(size_of::<&mut u64>(), USIZE_64BIT_IN_BYTES);
     }
 
     #[test]
     fn ticket_ref_size() {
-        assert_eq!(size_of::<&Ticket>(), size_of::<usize>());
+        assert_eq!(size_of::<&Ticket>(), USIZE_64BIT_IN_BYTES);
     }
 }


### PR DESCRIPTION
Introduces constant values to tests instead of dynamic that can fail occasionally